### PR TITLE
fixed broken github link

### DIFF
--- a/about.html
+++ b/about.html
@@ -80,7 +80,7 @@
 
 		        		<p>If you have any questions feel free to contact us at ryersonlug@gmail.com</p>
 
-		        		<p><a href="https://github.com/LinuxUserGroup-RU">Our Github</a></p>
+		        		<p><a href="https://github.com/LUGRyerson">Our Github</a></p>
 
 		        		<p><a href="https://www.facebook.com/RULUG/">Our Facebook Page</a></p>
 						


### PR DESCRIPTION
Hi @veragluz 
Currently URL 404's, changed to the url for the group that this repo lives in.